### PR TITLE
Fix code scanning alert no. 17: Wrong type of arguments to formatting function

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5675,7 +5675,7 @@ int npc_parsesrcfile(const char* filepath)
 
 		// fill w3
 		if( pos[7]-pos[6] > ARRAYLENGTH(w3)-1 )
-			ShowWarning("npc_parsesrcfile: w3 truncated, too much data (%d) in file '%s', line '%d'.\n", pos[7]-pos[6], filepath, strline(buffer,p-buffer));
+			ShowWarning("npc_parsesrcfile: w3 truncated, too much data (%lu) in file '%s', line '%d'.\n", pos[7]-pos[6], filepath, strline(buffer,p-buffer));
 
 		index = std::min( pos[7] - pos[6], ARRAYLENGTH( w3 ) - 1 );
 		memcpy( w3, p + pos[6], index * sizeof( char ) );


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/17](https://github.com/AoShinRO/brHades/security/code-scanning/17)

To fix the problem, we need to ensure that the format specifier in the `ShowWarning` function matches the type of the argument. Since `pos[7]-pos[6]` is of type `unsigned long`, we should use the `%lu` format specifier instead of `%d`.

- Update the format specifier in the `ShowWarning` function call on line 5678 to `%lu`.
- Ensure that similar changes are made to other `ShowWarning` calls if they also involve `unsigned long` arguments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
