### PR TITLE
Fix code scanning alert no. 31: Wrong type of arguments to formatting function

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -3014,7 +3014,7 @@ static bool itemdb_read_db(const char* file) {
 	}
 
 	fclose(fp);
-	ShowStatus("Done reading '" CL_WHITE "%d" CL_RESET "' items in '" CL_WHITE "%s" CL_RESET "'.\n", entries, file);
+	ShowStatus("Done reading '" CL_WHITE "%lu" CL_RESET "' items in '" CL_WHITE "%s" CL_RESET "'.\n", entries, file);
 
 	return true;
 }


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/31](https://github.com/AoShinRO/brHades/security/code-scanning/31)

To fix the problem, we need to ensure that the format specifier matches the type of the variable `entries`. Since `entries` is of type `unsigned long`, we should use the `%lu` format specifier, which is designed for `unsigned long` integers. This change will ensure that the `printf` function interprets the argument correctly, preventing any undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
