### PR TITLE
Fix code scanning alert no. 30: Wrong type of arguments to formatting function

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -3122,7 +3122,7 @@ static bool itemdb_read_randomopt_group( char* str[], size_t columns, size_t cur
 		}
 
 		if (randid_tmp < 0) {
-			ShowError("itemdb_read_randomopt_group: Invalid random group id '%s' in column %d!\n", str[k], k + 1);
+			ShowError("itemdb_read_randomopt_group: Invalid random group id '%s' in column %zu!\n", str[k], k + 1);
 			continue;
 		}
 


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/30](https://github.com/AoShinRO/brHades/security/code-scanning/30)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since `k + 1` is of type `size_t`, we should use the `%zu` format specifier, which is designed for `size_t` arguments. This change will ensure that the argument is interpreted correctly by the `printf` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
