### PR TITLE
Fix code scanning alert no. 29: Wrong type of arguments to formatting function

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -3099,7 +3099,7 @@ static bool itemdb_read_randomopt(const char* file) {
 // Copied and adjusted from itemdb.cpp
 static bool itemdb_read_randomopt_group( char* str[], size_t columns, size_t current ){
 	if ((columns - 2) % 3 != 0) {
-		ShowError("itemdb_read_randomopt_group: Invalid column entries '%d'.\n", columns);
+		ShowError("itemdb_read_randomopt_group: Invalid column entries '%zu'.\n", columns);
 		return false;
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/29](https://github.com/AoShinRO/brHades/security/code-scanning/29)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since `columns` is of type `size_t`, we should use the `%zu` format specifier, which is specifically designed for `size_t` arguments. This change will ensure that the `printf` function interprets the argument correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
