### PR TITLE
Fix code scanning alert no. 27: Wrong type of arguments to formatting function

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -3710,7 +3710,7 @@ static bool mob_parse_row_chatdb( char* fields[], size_t columns, size_t current
 	int msg_id = atoi(fields[0]);
 
 	if (msg_id <= 0){
-		ShowError("Invalid chat ID '%d' in line %d\n", msg_id, current);
+		ShowError("Invalid chat ID '%d' in line %zu\n", msg_id, current);
 		return false;
 	}
 
@@ -3722,7 +3722,7 @@ static bool mob_parse_row_chatdb( char* fields[], size_t columns, size_t current
 	}
 
 	if (len > (CHAT_SIZE_MAX-1)) {
-		ShowError("Message too long! Line %d, id: %d\n", current, msg_id);
+		ShowError("Message too long! Line %zu, id: %d\n", current, msg_id);
 		return false;
 	}
 	else if (len == 0) {


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/27](https://github.com/AoShinRO/brHades/security/code-scanning/27)

To fix the problem, we need to ensure that the format specifier in the `ShowError` function matches the type of the `current` argument. Since `current` is of type `size_t`, we should use the `%zu` format specifier, which is specifically designed for `size_t` arguments.

- Change the format specifier from `%d` to `%zu` in the `ShowError` function calls.
- This change should be made in the file `src/tool/csv2yaml.cpp` at the specified lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
