### PR TITLE
Fix code scanning alert no. 25: Wrong type of arguments to formatting function

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -3972,7 +3972,7 @@ static bool itemdb_read_group( char* str[], size_t columns, size_t current ){
 		return false;
 	}
 	if (columns < 3) {
-		ShowError("itemdb_read_group: Insufficient columns (found %d, need at least 3).\n", columns);
+		ShowError("itemdb_read_group: Insufficient columns (found %zu, need at least 3).\n", columns);
 		return false;
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/25](https://github.com/AoShinRO/brHades/security/code-scanning/25)

To fix the problem, we need to update the format specifier in the `ShowError` function call to correctly match the type of the `columns` variable. Since `columns` is of type `size_t`, the appropriate format specifier is `%zu`, which is used for `size_t` types.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
