### PR TITLE
Fix code scanning alert no. 24: Wrong type of arguments to formatting function

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -4229,7 +4229,7 @@ static bool read_constdb( char* fields[], size_t columns, size_t current ){
 		}
 	}else{
 		if( sscanf(fields[0], "%1023[A-Za-z0-9/_] %1023[A-Za-z0-9/_-] %11d", name, val, &type) < 2 ){
-			ShowWarning( "Skipping line '" CL_WHITE "%d" CL_RESET "', invalid constant definition\n", current );
+			ShowWarning( "Skipping line '" CL_WHITE "%zu" CL_RESET "', invalid constant definition\n", current );
 			return false;
 		}
 	}


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/24](https://github.com/AoShinRO/brHades/security/code-scanning/24)

To fix the problem, we need to ensure that the format specifier matches the type of the variable `current`. Since `current` is of type `size_t`, we should use the `%zu` format specifier, which is specifically designed for `size_t` types. This change will ensure that the `ShowWarning` function correctly interprets the `current` variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
