### PR TITLE
Fix code scanning alert no. 23: Wrong type of arguments to formatting function

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -4224,7 +4224,7 @@ static bool read_constdb( char* fields[], size_t columns, size_t current ){
 		if( sscanf(fields[0], "%1023[A-Za-z0-9/_]", name) != 1 ||
 			sscanf(fields[1], "%1023[A-Za-z0-9/_]", val) != 1 || 
 			( columns >= 2 && sscanf(fields[2], "%11d", &type) != 1 ) ){
-			ShowWarning("Skipping line '" CL_WHITE "%d" CL_RESET "', invalid constant definition\n", current);
+			ShowWarning("Skipping line '" CL_WHITE "%zu" CL_RESET "', invalid constant definition\n", current);
 			return false;
 		}
 	}else{


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/23](https://github.com/AoShinRO/brHades/security/code-scanning/23)

To fix the problem, we need to ensure that the format specifier matches the type of the variable being passed. Since `current` is of type `size_t`, we should use the `%zu` format specifier, which is specifically for `size_t` type variables. This change will ensure that the `ShowWarning` function correctly interprets the `current` variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
