### PR TITLE
Fix code scanning alert no. 22: Wrong type of arguments to formatting function

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -4955,10 +4955,10 @@ static bool cashshop_parse_dbrow( char* fields[], size_t columns, size_t current
 	}
 
 	if( tab >= CASHSHOP_TAB_MAX ){
-		ShowWarning( "cashshop_parse_dbrow: Invalid tab %d in line '%d', skipping...\n", tab, current );
+		ShowWarning( "cashshop_parse_dbrow: Invalid tab %d in line '%zu', skipping...\n", tab, current );
 		return false;
 	}else if( price < 1 ){
-		ShowWarning( "cashshop_parse_dbrow: Invalid price %d in line '%d', skipping...\n", price, current );
+		ShowWarning( "cashshop_parse_dbrow: Invalid price %d in line '%zu', skipping...\n", price, current );
 		return false;
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/22](https://github.com/AoShinRO/brHades/security/code-scanning/22)

To fix the problem, we need to ensure that the format specifier matches the type of the variable being printed. Since `current` is of type `size_t`, we should use the `%zu` format specifier, which is specifically for `size_t` type.

- Change the format specifier from `%d` to `%zu` for the `current` variable in the `ShowWarning` function calls.
- This change should be made on lines 4958 and 4961.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
