### PR TITLE
Fix code scanning alert no. 20: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -3276,7 +3276,7 @@ static bool mob_readdb_race2( char *fields[], size_t columns, size_t current ){
 
 	std::vector<uint32> mobs;
 
-	for (uint16 i = 1; i < columns; i++) {
+	for (size_t i = 1; i < columns; i++) {
 		uint32 mob_id = strtol(fields[i], nullptr, 10);
 		std::string *mob_name = util::umap_find(aegis_mobnames, static_cast<uint16>(mob_id));
 


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/20](https://github.com/AoShinRO/brHades/security/code-scanning/20)

To fix the problem, we need to ensure that the type of the loop variable `i` is at least as wide as the type of `columns`. The best way to achieve this is to change the type of `i` from `uint16` to `size_t`, which matches the type of `columns`. This change will prevent any potential overflow issues and ensure that the comparison is valid.

**Steps to fix:**
1. Change the type of the loop variable `i` from `uint16` to `size_t` in the `mob_readdb_race2` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
