### PR TITLE
Fix code scanning alert no. 14: Wrong type of arguments to formatting function

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -6003,7 +6003,7 @@ static bool mob_parse_row_mobskilldb( char** str, size_t columns, size_t current
 	if( j < ARRAYLENGTH(state) )
 		ms->state = state[j].id;
 	else {
-		ShowError("mob_parse_row_mobskilldb: Unrecognized state '%s' in line %d\n", str[2], current);
+		ShowError("mob_parse_row_mobskilldb: Unrecognized state '%s' in line %lu\n", str[2], current);
 		return false;
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/14](https://github.com/AoShinRO/brHades/security/code-scanning/14)

To fix the problem, we need to ensure that the format specifier matches the type of the variable `current`. Since `current` is of type `unsigned long`, we should use the `%lu` format specifier, which is designed for `unsigned long` integers.

- Change the format specifier from `%d` to `%lu` in the `ShowError` function call on line 6006.
- This change ensures that the `unsigned long` value of `current` is correctly formatted and displayed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
