### PR TITLE
Fix code scanning alert no. 18: Wrong type of arguments to formatting function

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5683,7 +5683,7 @@ int npc_parsesrcfile(const char* filepath)
 
 		// fill w4 (to end of line)
 		if( pos[1]-pos[8] > ARRAYLENGTH(w4)-1 )
-			ShowWarning("npc_parsesrcfile: w4 truncated, too much data (%d) in file '%s', line '%d'.\n", pos[1]-pos[8], filepath, strline(buffer,p-buffer));
+			ShowWarning("npc_parsesrcfile: w4 truncated, too much data (%lu) in file '%s', line '%d'.\n", pos[1]-pos[8], filepath, strline(buffer,p-buffer));
 		if (pos[8] != -1) {
 			index = std::min( pos[1] - pos[8], ARRAYLENGTH( w4 ) - 1 );
 			memcpy( w4, p + pos[8], index * sizeof( char ) );


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/18](https://github.com/AoShinRO/brHades/security/code-scanning/18)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since `pos[1]-pos[8]` is of type `unsigned long`, we should use the `%lu` format specifier, which is designed for `unsigned long` values. This change will ensure that the `ShowWarning` function correctly interprets the argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
