### PR TITLE
Fix code scanning alert no. 16: Wrong type of arguments to formatting function

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5667,7 +5667,7 @@ int npc_parsesrcfile(const char* filepath)
 
 		// fill w2
 		if( pos[5]-pos[4] > ARRAYLENGTH(w2)-1 )
-			ShowWarning("npc_parsesrcfile: w2 truncated, too much data (%d) in file '%s', line '%d'.\n", pos[5]-pos[4], filepath, strline(buffer,p-buffer));
+			ShowWarning("npc_parsesrcfile: w2 truncated, too much data (%zu) in file '%s', line '%d'.\n", pos[5]-pos[4], filepath, strline(buffer,p-buffer));
 
 		index = std::min( pos[5] - pos[4], ARRAYLENGTH( w2 ) - 1 );
 		memcpy( w2, p + pos[4], index * sizeof( char ) );


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/16](https://github.com/AoShinRO/brHades/security/code-scanning/16)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since `pos[5]-pos[4]` is of type `size_t`, we should use the `%zu` format specifier, which is designed for `size_t` arguments. This change will ensure that the `ShowWarning` function correctly interprets the argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
