### PR TITLE
Fix code scanning alert no. 15: Wrong type of arguments to formatting function

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5659,7 +5659,7 @@ int npc_parsesrcfile(const char* filepath)
 
 		// fill w1
 		if( pos[3]-pos[2] > ARRAYLENGTH(w1)-1 )
-			ShowWarning("npc_parsesrcfile: w1 truncated, too much data (%d) in file '%s', line '%d'.\n", pos[3]-pos[2], filepath, strline(buffer,p-buffer));
+			ShowWarning("npc_parsesrcfile: w1 truncated, too much data (%zu) in file '%s', line '%d'.\n", pos[3]-pos[2], filepath, strline(buffer,p-buffer));
 
 		size_t index = std::min( pos[3] - pos[2], ARRAYLENGTH( w1 ) - 1 );
 		memcpy( w1, p + pos[2], index * sizeof( char ) );
@@ -5667,7 +5667,7 @@ int npc_parsesrcfile(const char* filepath)
 
 		// fill w2
 		if( pos[5]-pos[4] > ARRAYLENGTH(w2)-1 )
-			ShowWarning("npc_parsesrcfile: w2 truncated, too much data (%d) in file '%s', line '%d'.\n", pos[5]-pos[4], filepath, strline(buffer,p-buffer));
+			ShowWarning("npc_parsesrcfile: w2 truncated, too much data (%zu) in file '%s', line '%d'.\n", pos[5]-pos[4], filepath, strline(buffer,p-buffer));
 
 		index = std::min( pos[5] - pos[4], ARRAYLENGTH( w2 ) - 1 );
 		memcpy( w2, p + pos[4], index * sizeof( char ) );


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/15](https://github.com/AoShinRO/brHades/security/code-scanning/15)

To fix the problem, we need to change the format specifier from `%d` to `%zu`, which is the correct format specifier for `size_t` in C++. This change ensures that the type of the argument matches the expected type of the format specifier, preventing any potential issues related to type mismatches.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
