### PR TITLE
Fix code scanning alert no. 13: Wrong type of arguments to formatting function

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -7987,7 +7987,7 @@ void clif_party_message( struct party_data& party, uint32 account_id, const char
 	}
 
 	if (len > CHAT_SIZE_MAX) {
-		ShowWarning( "clif_party_message: Truncated message '%s' (len=%d, max=%" PRIuPTR ", party_id=%d).\n", mes, len, CHAT_SIZE_MAX, party.party.party_id );
+		ShowWarning( "clif_party_message: Truncated message '%s' (len=%zu, max=%" PRIuPTR ", party_id=%d).\n", mes, len, CHAT_SIZE_MAX, party.party.party_id );
 		len = CHAT_SIZE_MAX;
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/13](https://github.com/AoShinRO/brHades/security/code-scanning/13)

To fix the problem, we need to ensure that the format specifier matches the type of the variable `len`, which is `size_t`. The correct format specifier for `size_t` is `%zu`. We will replace `%d` with `%zu` in the `ShowWarning` function call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
