### PR TITLE
Fix code scanning alert no. 12: Wrong type of arguments to formatting function

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -9417,7 +9417,7 @@ void clif_disp_message(struct block_list* src, const char* mes, size_t len, enum
 	if( len == 0 ) {
 		return;
 	} else if( len > sizeof(buf)-5 ) {
-		ShowWarning("clif_disp_message: Truncated message '%s' (len=%d, max=%" PRIuPTR ", aid=%d).\n", mes, len, sizeof(buf)-5, src->id);
+		ShowWarning("clif_disp_message: Truncated message '%s' (len=%zu, max=%zu, aid=%d).\n", mes, len, sizeof(buf)-5, src->id);
 		len = sizeof(buf)-5;
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/12](https://github.com/AoShinRO/brHades/security/code-scanning/12)

To fix the problem, we need to update the format specifiers in the `ShowWarning` function call to match the types of the arguments being passed. Specifically:
1. Use `%zu` for `size_t` type arguments (`len` and `sizeof(buf)-5`).
2. Verify the type of `src->id` and use the appropriate format specifier.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
