### PR TITLE
Fix code scanning alert no. 11: Wrong type of arguments to formatting function

### DIFF
--- a/src/common/strlib.cpp
+++ b/src/common/strlib.cpp
@@ -962,7 +962,7 @@ bool sv_readdb( const char* directory, const char* filename, char delim, size_t 
 	aFree(fields);
 	aFree(line);
 	fclose(fp);
-	ShowStatus("Done reading '" CL_WHITE "%d" CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "'.\n", entries, path);
+	ShowStatus("Done reading '" CL_WHITE "%zu" CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "'.\n", entries, path);
 
 	return true;
 }


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/11](https://github.com/AoShinRO/brHades/security/code-scanning/11)

To fix the problem, we need to ensure that the format specifier matches the type of the `entries` variable. Since `entries` is of type `size_t`, the correct format specifier to use is `%zu`, which is specifically for `size_t` types. This change will ensure that the `ShowStatus` function correctly interprets the `entries` variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
