### PR TITLE
Fix code scanning alert no. 10: Wrong type of arguments to formatting function

### DIFF
--- a/src/common/strlib.cpp
+++ b/src/common/strlib.cpp
@@ -942,7 +942,7 @@ bool sv_readdb( const char* directory, const char* filename, char delim, size_t 
 		}
 		if( entries == maxrows )
 		{
-			ShowError("sv_readdb: Reached the maximum allowed number of entries (%d) when parsing file \"%s\".\n", maxrows, path);
+			ShowError("sv_readdb: Reached the maximum allowed number of entries (%lu) when parsing file \"%s\".\n", maxrows, path);
 			break;
 		}
 


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/10](https://github.com/AoShinRO/brHades/security/code-scanning/10)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since `maxrows` is of type `unsigned long`, we should use the `%lu` format specifier, which is designed for `unsigned long` values. This change will ensure that the `ShowError` function correctly interprets the `maxrows` argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
