### PR TITLE
Fix code scanning alert no. 9: Wrong type of arguments to formatting function

### DIFF
--- a/src/common/strlib.cpp
+++ b/src/common/strlib.cpp
@@ -937,7 +937,7 @@ bool sv_readdb( const char* directory, const char* filename, char delim, size_t 
 		}
 		if( columns > maxcols )
 		{
-			ShowError("sv_readdb: Too many columns in line %d of \"%s\" (found %d, maximum is %d).\n", lines, path, columns, maxcols );
+			ShowError("sv_readdb: Too many columns in line %d of \"%s\" (found %d, maximum is %lu).\n", lines, path, columns, maxcols );
 			continue; // too many columns
 		}
 		if( entries == maxrows )


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/9](https://github.com/AoShinRO/brHades/security/code-scanning/9)

To fix the problem, we need to ensure that the format specifier matches the type of the argument being passed. In this case, `maxcols` is of type `unsigned long`, so we should use the `%lu` format specifier instead of `%d`. This change should be applied to all instances where `maxcols` is used in a `ShowError` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
