### PR TITLE
Fix code scanning alert no. 8: Wrong type of arguments to formatting function

### DIFF
--- a/src/common/strlib.cpp
+++ b/src/common/strlib.cpp
@@ -937,7 +937,7 @@ bool sv_readdb( const char* directory, const char* filename, char delim, size_t 
 		}
 		if( columns > maxcols )
 		{
-			ShowError("sv_readdb: Too many columns in line %d of \"%s\" (found %d, maximum is %d).\n", lines, path, columns, maxcols );
+			ShowError("sv_readdb: Too many columns in line %d of \"%s\" (found %zu, maximum is %d).\n", lines, path, columns, maxcols );
 			continue; // too many columns
 		}
 		if( entries == maxrows )


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/8](https://github.com/AoShinRO/brHades/security/code-scanning/8)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since `columns` is of type `size_t`, we should use the `%zu` format specifier, which is specifically designed for `size_t` arguments. This change will ensure that the `printf` function interprets the argument correctly, preventing any undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
