### PR TITLE
Fix code scanning alert no. 7: Wrong type of arguments to formatting function

### DIFF
--- a/src/common/strlib.cpp
+++ b/src/common/strlib.cpp
@@ -932,7 +932,7 @@ bool sv_readdb( const char* directory, const char* filename, char delim, size_t 
 
 		if( columns < mincols )
 		{
-			ShowError("sv_readdb: Insufficient columns in line %d of \"%s\" (found %d, need at least %d).\n", lines, path, columns, mincols);
+			ShowError("sv_readdb: Insufficient columns in line %d of \"%s\" (found %d, need at least %lu).\n", lines, path, columns, mincols);
 			continue; // not enough columns
 		}
 		if( columns > maxcols )


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/7](https://github.com/AoShinRO/brHades/security/code-scanning/7)

To fix the problem, we need to ensure that the format specifier in the `ShowError` function matches the type of the `mincols` argument. Since `mincols` is identified as an `unsigned long`, we should use the `%lu` format specifier, which is appropriate for `unsigned long` types.

- Update the format specifier in the `ShowError` function call on line 935 to `%lu`.
- Verify and update any other instances where `mincols` is used with a format specifier to ensure consistency.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
