### PR TITLE
Fix code scanning alert no. 6: Wrong type of arguments to formatting function

### DIFF
--- a/src/common/strlib.cpp
+++ b/src/common/strlib.cpp
@@ -932,12 +932,12 @@ bool sv_readdb( const char* directory, const char* filename, char delim, size_t 
 
 		if( columns < mincols )
 		{
-			ShowError("sv_readdb: Insufficient columns in line %d of \"%s\" (found %d, need at least %d).\n", lines, path, columns, mincols);
+			ShowError("sv_readdb: Insufficient columns in line %d of \"%s\" (found %zu, need at least %d).\n", lines, path, columns, mincols);
 			continue; // not enough columns
 		}
 		if( columns > maxcols )
 		{
-			ShowError("sv_readdb: Too many columns in line %d of \"%s\" (found %d, maximum is %d).\n", lines, path, columns, maxcols );
+			ShowError("sv_readdb: Too many columns in line %d of \"%s\" (found %zu, maximum is %d).\n", lines, path, columns, maxcols );
 			continue; // too many columns
 		}
 		if( entries == maxrows )


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/6](https://github.com/AoShinRO/brHades/security/code-scanning/6)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. The `size_t` type is typically used for sizes and counts and is an unsigned type. The correct format specifier for `size_t` is `%zu`. We will update the format specifier in the `ShowError` function calls to use `%zu` for `columns`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
