### PR TITLE
Fix code scanning alert no. 5: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -17418,12 +17418,12 @@ BUILDIN_FUNC(sscanf){
 			if(ref_str==nullptr){
 				CREATE(ref_str, char, strlen(str)+1);
 			}
-			if(sscanf(str, buf, ref_str)==0){
+			if(sscanf(str, buf, ref_str) != 1){
 				break;
 			}
 			set_reg_str( st, sd, reference_uid( reference_getid( data ), reference_getindex( data ) ), buf_p, ref_str, reference_getref( data ) );
 		} else {  // Number
-			if(sscanf(str, buf, &ref_int)==0){
+			if(sscanf(str, buf, &ref_int) != 1){
 				break;
 			}
 			set_reg_num( st, sd, reference_uid( reference_getid( data ), reference_getindex( data ) ), buf_p, ref_int, reference_getref( data ) );


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/5](https://github.com/AoShinRO/brHades/security/code-scanning/5)

To fix the problem, we need to ensure that the return value of `sscanf` is checked against the expected number of arguments rather than just zero. Specifically, we should check if the return value is less than the expected number of matches or if it is `EOF`. This will ensure that all possible return values are handled correctly.

In the provided code, there are two instances of `sscanf` that need to be fixed. We will update the checks to ensure they handle `EOF` and the expected number of matches correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
