### PR TITLE
Fix code scanning alert no. 4: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -17418,12 +17418,18 @@ BUILDIN_FUNC(sscanf){
 			if(ref_str==nullptr){
 				CREATE(ref_str, char, strlen(str)+1);
 			}
-			if(sscanf(str, buf, ref_str)==0){
+			if(sscanf(str, buf, ref_str) != 1){
+				if (sscanf(str, buf, ref_str) == EOF) {
+					// Handle EOF case if necessary
+				}
 				break;
 			}
 			set_reg_str( st, sd, reference_uid( reference_getid( data ), reference_getindex( data ) ), buf_p, ref_str, reference_getref( data ) );
 		} else {  // Number
-			if(sscanf(str, buf, &ref_int)==0){
+			if(sscanf(str, buf, &ref_int) != 1){
+				if (sscanf(str, buf, &ref_int) == EOF) {
+					// Handle EOF case if necessary
+				}
 				break;
 			}
 			set_reg_num( st, sd, reference_uid( reference_getid( data ), reference_getindex( data ) ), buf_p, ref_int, reference_getref( data ) );

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -17419,17 +17419,11 @@ BUILDIN_FUNC(sscanf){
 				CREATE(ref_str, char, strlen(str)+1);
 			}
 			if(sscanf(str, buf, ref_str) != 1){
-				if (sscanf(str, buf, ref_str) == EOF) {
-					// Handle EOF case if necessary
-				}
 				break;
 			}
 			set_reg_str( st, sd, reference_uid( reference_getid( data ), reference_getindex( data ) ), buf_p, ref_str, reference_getref( data ) );
 		} else {  // Number
 			if(sscanf(str, buf, &ref_int) != 1){
-				if (sscanf(str, buf, &ref_int) == EOF) {
-					// Handle EOF case if necessary
-				}
 				break;
 			}
 			set_reg_num( st, sd, reference_uid( reference_getid( data ), reference_getindex( data ) ), buf_p, ref_int, reference_getref( data ) );


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/4](https://github.com/AoShinRO/brHades/security/code-scanning/4)

To fix the problem, we need to ensure that the return value of `sscanf` is checked against the expected number of items to be read, and handle the `EOF` case appropriately. Specifically, we should:
1. Check if the return value of `sscanf` is equal to the expected number of items (1 for strings and 1 for numbers in this case).
2. Handle the case where `sscanf` returns `EOF` by breaking out of the loop or handling the error as needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
