### PR TITLE
Fix code scanning alert no. 3: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/src/common/core.cpp
+++ b/src/common/core.cpp
@@ -272,7 +272,7 @@ const char *get_git_hash (void) {
 		char line[64];
 		char *rev = (char*)malloc(sizeof(char) * 50);
 
-		if( fgets(line, sizeof(line), fp) && sscanf(line, "%40s", rev) )
+		if( fgets(line, sizeof(line), fp) && sscanf(line, "%40s", rev) == 1 )
 			snprintf(GitHash, sizeof(GitHash), "%s", rev);
 
 		free(rev);


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/3](https://github.com/AoShinRO/brHades/security/code-scanning/3)

To fix the problem, we need to ensure that the return value of `sscanf` is checked against the expected number of arguments rather than just being non-zero. Specifically, we should check if `sscanf` returns 1, which indicates that one item was successfully read and assigned. Additionally, we should handle the case where `sscanf` returns `EOF`.

- Modify the return value check of `sscanf` on line 275.
- Ensure that the code handles the case where `sscanf` returns `EOF`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
