### PR TITLE
Fix code scanning alert no. 1055: Use of potentially dangerous function

### DIFF
--- a/src/common/malloc.cpp
+++ b/src/common/malloc.cpp
@@ -533,19 +533,20 @@ static void memmgr_log (char *buf)
 		const char* version;
 		time_t raw;
 		struct tm t;
-
+		char date[100];
 		log_fp = fopen(memmer_logfile,"at");
 		if (!log_fp) log_fp = stdout;
 
 		time(&raw);
-		localtime_r(&raw, &t);
+		localtime_s(&t, &raw);
+		strftime(date, sizeof(date), "%Y-%m-%d %H:%M:%S", &t);
 
 		if( ( version = get_git_hash() ) && version[0] != UNKNOWN_VERSION ){
-			fprintf(log_fp, "\nMemory manager: Memory leaks found at %d/%02d/%02d %02dh%02dm%02ds (Git Hash %s).\n", (t->tm_year+1900), (t->tm_mon+1), t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, version );
+			fprintf(log_fp, "\nMemory manager: Memory leaks found at %s (Git Hash %s).\n", date , version );
 		}else if( ( version = get_svn_revision() ) && version[0] != UNKNOWN_VERSION ){
-			fprintf(log_fp, "\nMemory manager: Memory leaks found at %d/%02d/%02d %02dh%02dm%02ds (SVN Revision %s).\n", (t->tm_year + 1900), (t->tm_mon + 1), t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, version );
+			fprintf(log_fp, "\nMemory manager: Memory leaks found at %s (SVN Revision %s).\n", date, version );
 		}else{
-			fprintf(log_fp, "\nMemory manager: Memory leaks found at %d/%02d/%02d %02dh%02dm%02ds (Unknown version).\n", (t->tm_year + 1900), (t->tm_mon + 1), t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec );
+			fprintf(log_fp, "\nMemory manager: Memory leaks found at %s (Unknown version).\n", date );
 		}
 	}
 	fprintf(log_fp, "%s", buf);

--- a/src/common/malloc.cpp
+++ b/src/common/malloc.cpp
@@ -532,13 +532,13 @@ static void memmgr_log (char *buf)
 	{
 		const char* version;
 		time_t raw;
-		struct tm* t;
+		struct tm t;
 
 		log_fp = fopen(memmer_logfile,"at");
 		if (!log_fp) log_fp = stdout;
 
 		time(&raw);
-		t = localtime(&raw);
+		localtime_r(&raw, &t);
 
 		if( ( version = get_git_hash() ) && version[0] != UNKNOWN_VERSION ){
 			fprintf(log_fp, "\nMemory manager: Memory leaks found at %d/%02d/%02d %02dh%02dm%02ds (Git Hash %s).\n", (t->tm_year+1900), (t->tm_mon+1), t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, version );


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1055](https://github.com/AoShinRO/brHades/security/code-scanning/1055)

To fix the problem, we need to replace the call to `localtime` with `localtime_r`. The `localtime_r` function requires an additional argument: a pointer to a `tm` structure where the result will be stored. This change ensures that each call to `localtime_r` uses its own storage, preventing data races and overwrites.

**Steps to fix:**
1. Declare a `tm` structure to hold the result of `localtime_r`.
2. Replace the call to `localtime` with `localtime_r`, passing the `tm` structure as an argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
