### PR TITLE
Fix code scanning alert no. 1245: Potentially unsafe use of strcat

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -565,11 +565,11 @@ static void warp_get_suggestions(map_session_data* sd, const char *name) {
 
 	// build the suggestion string
 	strcpy(buffer, msg_txt(sd, 205)); // Maybe you meant:
-	strcat(buffer, "\n");
+	strncat(buffer, "\n", CHAT_SIZE_MAX - strlen(buffer) - 1);
 
 	for( const char* suggestion : suggestions ){
-		strcat(buffer, suggestion);
-		strcat(buffer, " ");
+		strncat(buffer, suggestion, CHAT_SIZE_MAX - strlen(buffer) - 1);
+		strncat(buffer, " ", CHAT_SIZE_MAX - strlen(buffer) - 1);
 	}
 
 	clif_displaymessage(sd->fd, buffer);


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1245](https://github.com/AoShinRO/brHades/security/code-scanning/1245)

To fix the problem, we should replace the unsafe `strcat` calls with `strncat`, which allows us to specify the maximum number of characters to append, thus preventing buffer overflow. We need to calculate the remaining space in the buffer before each concatenation and ensure that we do not exceed `CHAT_SIZE_MAX`.

1. Replace `strcat` with `strncat` to ensure that the buffer size is not exceeded.
2. Calculate the remaining space in the buffer before each concatenation.
3. Ensure that the total length of the concatenated string does not exceed `CHAT_SIZE_MAX`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
