### PR TITLE
Fix code scanning alert no. 1116: Unbounded write

### DIFF
--- a/src/tool/mapcache.cpp
+++ b/src/tool/mapcache.cpp
@@ -75,13 +75,13 @@ int read_map(char *name, struct map_data *m)
 	size_t xy, off, num_cells;
 
 	// Open map GAT
-	sprintf(filename,"data\\%s.gat", name);
+	snprintf(filename, sizeof(filename), "data\\%s.gat", name);
 	gat = (unsigned char *)grfio_reads(filename);
 	if (gat == nullptr)
 		return 0;
 
 	// Open map RSW
-	sprintf(filename,"data\\%s.rsw", name);
+	snprintf(filename, sizeof(filename), "data\\%s.rsw", name);
 
 	// Read water height
 	water_height = grfio_read_rsw_water_level( filename );


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1116](https://github.com/AoShinRO/brHades/security/code-scanning/1116)

To fix the problem, we should replace the `sprintf` calls with `snprintf` to ensure that the buffer size is not exceeded. This change will prevent potential buffer overflow by specifying the maximum number of characters to be written to the buffer.

- Replace `sprintf(filename, "data\\%s.gat", name);` with `snprintf(filename, sizeof(filename), "data\\%s.gat", name);`.
- Replace `sprintf(filename, "data\\%s.rsw", name);` with `snprintf(filename, sizeof(filename), "data\\%s.rsw", name);`.

These changes ensure that the formatted string will not exceed the size of the `filename` buffer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
