### PR TITLE
Fix code scanning alert no. 1082: Use of potentially dangerous function

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -2151,8 +2151,9 @@ void run_tomb(map_session_data* sd, struct npc_data* nd)
 {
 	char buffer[200];
 	char time[10];
+	struct tm tm;
 
-	strftime(time, sizeof(time), "%H:%M", localtime(&nd->u.tomb.kill_time));
+	strftime(time, sizeof(time), "%H:%M", localtime_r(&nd->u.tomb.kill_time, &tm));
 
 	// TODO: Find exact color?
 	snprintf( buffer, sizeof( buffer ), msg_txt( sd, 657 ), nd->u.tomb.md->db->name.c_str() ); // [ ^EE0000%s^000000 ]


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1082](https://github.com/AoShinRO/brHades/security/code-scanning/1082)

To fix the problem, we need to replace the call to `localtime` with `localtime_r`. This change ensures that the `tm` structure is allocated by the caller, making the function call thread-safe. Specifically, we will:
1. Declare a `tm` structure to hold the time data.
2. Use `localtime_r` to populate this structure.
3. Pass the populated structure to `strftime` for formatting.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
