### PR TITLE
Fix code scanning alert no. 1113: Unbounded write

### DIFF
--- a/src/common/malloc.cpp
+++ b/src/common/malloc.cpp
@@ -656,7 +656,7 @@ static void memmgr_final (void)
 static void memmgr_init (void)
 {
 #ifdef LOG_MEMMGR
-	sprintf(memmer_logfile, "log/%s.leaks", SERVER_NAME);
+	snprintf(memmer_logfile, sizeof(memmer_logfile), "log/%s.leaks", SERVER_NAME);
 	ShowStatus("Memory manager initialised: " CL_WHITE "%s" CL_RESET "\n", memmer_logfile);
 	memset(hash_unfill, 0, sizeof(hash_unfill));
 #endif /* LOG_MEMMGR */


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1113](https://github.com/AoShinRO/brHades/security/code-scanning/1113)

To fix the problem, we should replace the `sprintf` call with `snprintf`, which allows us to specify the maximum number of characters to be written to the buffer. This will prevent buffer overflow by ensuring that the buffer is not overrun by the formatted string.

- Replace the `sprintf` call on line 659 in `src/common/malloc.cpp` with `snprintf`.
- Ensure that the size of the buffer `memmer_logfile` is passed to `snprintf` to limit the number of characters written.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
