### PR TITLE
Fix code scanning alert no. 1111: Unbounded write

### DIFF
--- a/src/common/grfio.cpp
+++ b/src/common/grfio.cpp
@@ -680,8 +680,8 @@ static bool grfio_parse_restable_row(const char* row)
 	if( strstr(w2, ".gat") == nullptr && strstr(w2, ".rsw") == nullptr )
 		return false; // we only need the maps' GAT and RSW files
 
-	sprintf(src, "data\\%s", w1);
-	sprintf(dst, "data\\%s", w2);
+	snprintf(src, sizeof(src), "data\\%s", w1);
+	snprintf(dst, sizeof(dst), "data\\%s", w2);
 
 	entry = filelist_find(dst);
 	if( entry != nullptr )


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1111](https://github.com/AoShinRO/brHades/security/code-scanning/1111)

To fix the problem, we should replace the `sprintf` calls with `snprintf` to ensure that the buffer size is not exceeded. The `snprintf` function allows us to specify the maximum number of characters to write, preventing buffer overflow. We need to update the `sprintf` calls on lines 683 and 684 to `snprintf`, specifying the size of the destination buffer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
