### PR TITLE
Fix code scanning alert no. 1056: Use of potentially dangerous function

### DIFF
--- a/src/common/showmsg.cpp
+++ b/src/common/showmsg.cpp
@@ -692,8 +692,9 @@ int _vShowMessage(enum msg_type flag, const char *string, va_list ap)
 		if( (log = fopen(console_log_filepath, "a+")) ) {
 			char timestring[255];
 			time_t curtime;
+			struct tm result;
 			time(&curtime);
-			strftime(timestring, 254, "%m/%d/%Y %H:%M:%S", localtime(&curtime));
+			strftime(timestring, 254, "%m/%d/%Y %H:%M:%S", localtime_r(&curtime, &result));
 			fprintf(log,"(%s) [ %s ] : ",
 				timestring,
 				flag == MSG_WARNING ? "Warning" :


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1056](https://github.com/AoShinRO/brHades/security/code-scanning/1056)

To fix the problem, we need to replace the call to `localtime` with `localtime_r`. The `localtime_r` function requires an additional argument: a pointer to a `tm` structure where the result will be stored. This change ensures that each call to `localtime_r` uses its own storage, making the code thread-safe.

- **General Fix:** Replace `localtime` with `localtime_r` and allocate a `tm` structure to store the result.
- **Detailed Fix:** In the file `src/common/showmsg.cpp`, modify the code around line 696 to use `localtime_r`. This involves declaring a `tm` structure and passing it to `localtime_r` along with the current time.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
