### PR TITLE
Fix code scanning alert no. 1057: Use of potentially dangerous function

### DIFF
--- a/src/common/showmsg.cpp
+++ b/src/common/showmsg.cpp
@@ -721,7 +721,8 @@ int _vShowMessage(enum msg_type flag, const char *string, va_list ap)
 	if (timestamp_format[0] && flag != MSG_NONE)
 	{	//Display time format. [Skotlex]
 		time_t t = time(nullptr);
-		strftime(prefix, 80, timestamp_format, localtime(&t));
+		struct tm t_local;
+		strftime(prefix, 80, timestamp_format, localtime_r(&t, &t_local));
 	} else prefix[0]='\0';
 
 	switch (flag) {


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1057](https://github.com/AoShinRO/brHades/security/code-scanning/1057)

To fix the problem, we need to replace the call to `localtime` with `localtime_r`. The `localtime_r` function requires an additional argument: a pointer to a `tm` structure where the result will be stored. This change ensures that each call to `localtime_r` uses its own storage, preventing data races and memory overwrites.

- Replace the call to `localtime` on line 724 with `localtime_r`.
- Allocate a `tm` structure to pass to `localtime_r`.
- Update the `strftime` call to use the `tm` structure filled by `localtime_r`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
