### PR TITLE
Fix code scanning alert no. 1061: Use of potentially dangerous function

### DIFF
--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -1113,8 +1113,9 @@ int chrif_ban(int fd) {
 		time_t timestamp;
 		char tmpstr[256];
 		char strtime[25];
+		struct tm timeinfo;
 		timestamp = (time_t)RFIFOL(fd,7); // status or final date of a banishment
-		strftime(strtime, 24, "%d-%m-%Y %H:%M:%S", localtime(&timestamp));
+		strftime(strtime, 24, "%d-%m-%Y %H:%M:%S", localtime_r(&timestamp, &timeinfo));
 		safesnprintf(tmpstr,sizeof(tmpstr),msg_txt(sd,423),res==2?"char":"account",strtime); //"Your %s has been banished until %s "
 		clif_displaymessage(sd->fd, tmpstr);
 	}


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1061](https://github.com/AoShinRO/brHades/security/code-scanning/1061)

To fix the problem, we need to replace the call to `localtime` with `localtime_r`. The `localtime_r` function requires the caller to provide a `tm` structure where the result will be stored, making it thread-safe. This change will ensure that the code remains safe even if it is executed in a multi-threaded context.

- Replace the call to `localtime` with `localtime_r`.
- Allocate a `tm` structure on the stack to hold the result of `localtime_r`.
- Update the code to use the `tm` structure returned by `localtime_r`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
