### PR TITLE
Fix code scanning alert no. 1062: Use of potentially dangerous function

### DIFF
--- a/src/map/date.cpp
+++ b/src/map/date.cpp
@@ -11,10 +11,10 @@
 int date_get_year(void)
 {
 	time_t t;
-	struct tm * lt;
+	struct tm lt;
 	t = time(nullptr);
-	lt = localtime(&t);
-	return lt->tm_year+1900;
+	localtime_r(&t, &lt);
+	return lt.tm_year+1900;
 }
 
 /*
@@ -35,10 +35,10 @@ enum e_month date_get_month(void)
 int date_get_dayofmonth(void)
 {
 	time_t t;
-	struct tm * lt;
+	struct tm lt;
 	t = time(nullptr);
-	lt = localtime(&t);
-	return lt->tm_mday;
+	localtime_r(&t, &lt);
+	return lt.tm_mday;
 }
 
 /*
@@ -47,10 +47,10 @@ int date_get_dayofmonth(void)
 enum e_dayofweek date_get_dayofweek(void)
 {
 	time_t t;
-	struct tm * lt;
+	struct tm lt;
 	t = time(nullptr);
-	lt = localtime(&t);
-	return (enum e_dayofweek)lt->tm_wday;
+	localtime_r(&t, &lt);
+	return (enum e_dayofweek)lt.tm_wday;
 }
 
 /*
@@ -59,10 +59,10 @@ enum e_dayofweek date_get_dayofweek(void)
 int date_get_dayofyear(void)
 {
 	time_t t;
-	struct tm * lt;
+	struct tm lt;
 	t = time(nullptr);
-	lt = localtime(&t);
-	return lt->tm_yday;
+	localtime_r(&t, &lt);
+	return lt.tm_yday;
 }
 
 /*
@@ -71,10 +71,10 @@ int date_get_dayofyear(void)
 int date_get_hour(void)
 {
 	time_t t;
-	struct tm * lt;
+	struct tm lt;
 	t = time(nullptr);
-	lt = localtime(&t);
-	return lt->tm_hour;
+	localtime_r(&t, &lt);
+	return lt.tm_hour;
 }
 
 /*
@@ -83,10 +83,10 @@ int date_get_hour(void)
 int date_get_min(void)
 {
 	time_t t;
-	struct tm * lt;
+	struct tm lt;
 	t = time(nullptr);
-	lt = localtime(&t);
-	return lt->tm_min;
+	localtime_r(&t, &lt);
+	return lt.tm_min;
 }
 
 /*
@@ -95,10 +95,10 @@ int date_get_min(void)
 int date_get_sec(void)
 {
 	time_t t;
-	struct tm * lt;
+	struct tm lt;
 	t = time(nullptr);
-	lt = localtime(&t);
-	return lt->tm_sec;
+	localtime_r(&t, &lt);
+	return lt.tm_sec;
 }
 
 /*


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1062](https://github.com/AoShinRO/brHades/security/code-scanning/1062)

To fix the problem, we need to replace the calls to `localtime` with `localtime_r`. This involves allocating a `tm` struct on the stack and passing it to `localtime_r` along with the `time_t` value. This change ensures that each call to `localtime_r` uses its own storage, making the code thread-safe.

- Replace each call to `localtime` with `localtime_r`.
- Allocate a `tm` struct on the stack in each function where `localtime` is called.
- Pass the `time_t` value and the address of the `tm` struct to `localtime_r`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
