### PR TITLE
Fix code scanning alert no. 1085: Use of potentially dangerous function

### DIFF
--- a/src/map/quest.cpp
+++ b/src/map/quest.cpp
@@ -560,8 +560,9 @@ static time_t quest_time(std::shared_ptr<s_quest_db> qi)
 		return time(nullptr) + qi->time;
 	else if (qi->time_at) {
 		time_t t = time(nullptr);
-		struct tm *lt = localtime(&t);
-		uint32 time_today = lt->tm_hour * 3600 + lt->tm_min * 60 + lt->tm_sec;
+		struct tm lt;
+		localtime_r(&t, &lt);
+		uint32 time_today = lt.tm_hour * 3600 + lt.tm_min * 60 + lt.tm_sec;
 
 		int32 day_shift = 0;
 


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1085](https://github.com/AoShinRO/brHades/security/code-scanning/1085)

To fix the problem, we should replace the call to `localtime` with `localtime_r`. The `localtime_r` function requires the caller to provide a `tm` structure, which eliminates the risk of data being overwritten by concurrent calls. 

**Steps to fix:**
1. Declare a `struct tm` variable to hold the time data.
2. Replace the call to `localtime` with `localtime_r`, passing the `tm` variable as an argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
