### PR TITLE
Fix code scanning alert no. 1087: Use of potentially dangerous function

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -10723,7 +10723,7 @@ BUILDIN_FUNC(gettimetick)	/* Asgard Version */
 {
 	int type;
 	time_t timer;
-	struct tm *t;
+	struct tm t;
 
 	type=script_getnum(st,2);
 
@@ -10736,8 +10736,8 @@ BUILDIN_FUNC(gettimetick)	/* Asgard Version */
 	case 1:
 		//type 1:(Second Ticks: 0-86399, 00:00:00-23:59:59)
 		time(&timer);
-		t=localtime(&timer);
-		script_pushint(st,((t->tm_hour)*3600+(t->tm_min)*60+t->tm_sec));
+		localtime_r(&timer, &t);
+		script_pushint(st,((t.tm_hour)*3600+(t.tm_min)*60+t.tm_sec));
 		break;
 	case 0:
 	default:


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1087](https://github.com/AoShinRO/brHades/security/code-scanning/1087)

To fix the problem, we need to replace the call to `localtime` with `localtime_r`. This change ensures that the `tm` structure is allocated by the caller, making the function thread-safe. Specifically, we will:
1. Declare a `struct tm` variable to hold the time information.
2. Use `localtime_r` to populate this `tm` structure.
3. Update the code to use the new `tm` structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
