### PR TITLE
Fix code scanning alert no. 1117: Potentially overrunning write with float to string conversion

### DIFF
--- a/src/map/homunculus.cpp
+++ b/src/map/homunculus.cpp
@@ -561,8 +561,9 @@ int hom_levelup(struct homun_data *hd)
 	clif_homskillinfoblock( *hd );
 
 	if ( hd->master && battle_config.homunculus_show_growth ) {
-		char output[256] ;
-		sprintf(output,
+		#define OUTPUT_BUFFER_SIZE 256
+		char output[OUTPUT_BUFFER_SIZE];
+		snprintf(output, OUTPUT_BUFFER_SIZE,
 			"Growth: hp:%d sp:%d str(%.2f) agi(%.2f) vit(%.2f) int(%.2f) dex(%.2f) luk(%.2f) ",
 			growth_max_hp, growth_max_sp,
 			growth_str/10.0, growth_agi/10.0, growth_vit/10.0,

--- a/src/map/homunculus.cpp
+++ b/src/map/homunculus.cpp
@@ -561,9 +561,8 @@ int hom_levelup(struct homun_data *hd)
 	clif_homskillinfoblock( *hd );
 
 	if ( hd->master && battle_config.homunculus_show_growth ) {
-		#define OUTPUT_BUFFER_SIZE 256
-		char output[OUTPUT_BUFFER_SIZE];
-		snprintf(output, OUTPUT_BUFFER_SIZE,
+		char output[CHAT_SIZE_MAX];
+		snprintf(output, CHAT_SIZE_MAX-1,
 			"Growth: hp:%d sp:%d str(%.2f) agi(%.2f) vit(%.2f) int(%.2f) dex(%.2f) luk(%.2f) ",
 			growth_max_hp, growth_max_sp,
 			growth_str/10.0, growth_agi/10.0, growth_vit/10.0,


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1117](https://github.com/AoShinRO/brHades/security/code-scanning/1117)

To fix the problem, we will replace the `sprintf` call with `snprintf`, specifying the buffer size to ensure that the output is truncated if it exceeds the buffer length. This will prevent the buffer overflow. Additionally, we will define the buffer size using a preprocessor define to make the code more maintainable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
