### PR TITLE
Fix code scanning alert no. 1110: Uncontrolled data used in path expression

### DIFF
--- a/src/web/web.cpp
+++ b/src/web/web.cpp
@@ -50,6 +50,7 @@ std::string login_server_id = "ragnarok";
 std::string login_server_pw = "";
 std::string login_server_db = "ragnarok";
 
+
 std::string char_server_ip = "127.0.0.1";
 uint16  char_server_port = 3306;
 std::string char_server_id = "ragnarok";
@@ -148,8 +149,13 @@ bool web_config_read(const char* cfgName, bool normal) {
 			safestrncpy(console_log_filepath, w2, sizeof(console_log_filepath));
 		else if (!strcmpi(w1, "print_req_res"))
 			web_config.print_req_res = config_switch(w2);
-		else if (!strcmpi(w1, "import"))
-			web_config_read(w2, normal);
+		else if (!strcmpi(w1, "import")) {
+			if (isValidPath(w2)) {
+				web_config_read(w2, normal);
+			} else {
+				ShowError("Invalid path in configuration: %s\n", w2);
+			}
+		}
 		else if (!strcmpi(w1, "allow_gifs"))
 			web_config.allow_gifs = config_switch(w2) == 1;
 	}


### PR DESCRIPTION
Fixes [https://github.com/AoShinRO/brHades/security/code-scanning/1110](https://github.com/AoShinRO/brHades/security/code-scanning/1110)

To fix the problem, we need to validate the input before using it to construct a file path. Specifically, we should ensure that the path does not contain any ".." sequences or path separators that could lead to directory traversal. We can achieve this by checking the contents of `w2` before making the recursive call to `web_config_read`.

1. Add a validation function to check for invalid sequences in the path.
2. Use this function to validate `w2` before calling `web_config_read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
