### PR TITLE
Correção do tamanho da arma chicote #8883

### DIFF
--- a/db/pre-re/size_fix.yml
+++ b/db/pre-re/size_fix.yml
@@ -36,3 +36,5 @@ Body:
   - Weapon: Knuckle
     Medium: 75
     Large: 50
+  - Weapon: Whip
+    Large: 50

--- a/db/re/size_fix.yml
+++ b/db/re/size_fix.yml
@@ -35,3 +35,5 @@ Header:
 Body:
   - Weapon: Knuckle
     Large: 75
+  - Weapon: Whip
+    Large: 75

--- a/db/size_fix.yml
+++ b/db/size_fix.yml
@@ -66,7 +66,6 @@ Body:
     Large: 75
   - Weapon: Whip
     Small: 75
-    Large: 50
   - Weapon: Book
     Large: 50
   - Weapon: Katar


### PR DESCRIPTION
* **Problema(s) Tratado(s)**:

Remoção do tamanho da arma chicote e adicionado a correção.
* **Modo do Servidor**:
Pré-Renewal, Renewal.
<!-- * a penalidade de tamanho em monstros grandes agora é de 75% na renovação. -->
